### PR TITLE
#17 #18 fix: Wrong use useTranslate

### DIFF
--- a/src/pages/ProjectText/ProjectVoiceOptions/Slider/index.tsx
+++ b/src/pages/ProjectText/ProjectVoiceOptions/Slider/index.tsx
@@ -1,5 +1,9 @@
-import * as S from '~/pages/ProjectText/ProjectVoiceOptions/Slider/styles';
 import { ChangeEvent, useCallback, useMemo } from 'react';
+
+import * as S from '~/pages/ProjectText/ProjectVoiceOptions/Slider/styles';
+
+import { useTranslate } from '../../translate/hooks';
+
 import { getDefaultNumber } from '~/utils/number';
 
 type Props = {
@@ -11,7 +15,7 @@ type Props = {
   onChange?: (e: { name: string; value: number }) => void;
   disabled?: boolean;
 
-  dataList: Array<{ value: number; text: string }>;
+  dataList: Array<{ value: number; labelKey: string | object }>;
 };
 
 const defaultValue: Partial<Props> = {
@@ -21,8 +25,9 @@ const defaultValue: Partial<Props> = {
 // TODO track 에 점은 나중에 더럽게 어렵네
 const Slider = (props: Props) => {
   const { name } = props;
-
   const { className, dataList, onChange, ...sliderProps } = props;
+  const { tu } = useTranslate();
+
   const onChangeHandler = useCallback(
     (e: ChangeEvent<HTMLInputElement>) => {
       onChange?.({ name, value: getDefaultNumber(e.target.value) });
@@ -45,9 +50,9 @@ const Slider = (props: Props) => {
       />
 
       <S.Datalist id={`${name}-dataList`}>
-        {dataList.map(({ value, text }) => (
+        {dataList.map(({ value, labelKey }) => (
           <option key={value} value={value}>
-            {text}
+            {tu(labelKey)}
           </option>
         ))}
       </S.Datalist>


### PR DESCRIPTION
## 사전 작업체크용 리스트
- [x] 제목 양식 맞추기!
  - `#이슈번호 [Commit 제목 형식] - 영어`
- [x] 라벨 넣기!
- [x] Assignees 넣기!
- [x] `yarn lint` 로 에러/경고 제거
- [x] `yarn format` 으로 코드포맷팅
- [x] `yarn build` 와 `yarn preview` 로 작동 확인

## PR 타입
- [x]  버그를 수정했어요.
- [ ]  새로운 기능을 추가했어요.
- [ ]  코드 스타일 업데이트를 했어요(포맷팅, 지역변수)
- [ ]  리팩토링을 했어요 (기능적인 변화 없이, api 변경 없이)
- [ ]  환경설정을 변경했어요.
- [ ]  문서 내용을 변경했어요.
- [ ]  기타 사항을 설명해 주세요.

## 설명
누락되서 잘 못 사용된 `useTranslate()` 재적용